### PR TITLE
Add optional validation to the config

### DIFF
--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -131,10 +131,10 @@ module FlightConfiguration
         end
 
         # Attempt to validate the config
-        validate!(config)
+        validate(config)
       end
     rescue => e
-      raise e, "Can not continue as the configuration is invalid:\n#{e.message}", e.backtrace
+      raise e, "Cannot continue as the configuration is invalid:\n#{e.message}", e.backtrace
     end
 
     def merge_sources
@@ -230,10 +230,10 @@ module FlightConfiguration
       end
     end
 
-    def validate!(config)
+    def validate(config)
       # Use active errors instead
       if active_errors?
-        validate_active_errors!(config)
+        validate_active_errors(config)
 
       # Attempt to use validate! instead
       elsif config.respond_to?(:validate!)
@@ -247,7 +247,7 @@ module FlightConfiguration
       end
     end
 
-    def validate_active_errors!(config)
+    def validate_active_errors(config)
       # Get the current state of the errors and validate
       current_errors = config.errors.dup
       return if config.valid? && current_errors.empty?

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -125,7 +125,7 @@ module FlightConfiguration
             else
               raise Error, "The required config has not been provided: #{key}"
             end
-          else
+          elsif config.respond_to?("#{key}=")
             config.send("#{key}=", transform(config, key, source.value))
           end
         end

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -134,7 +134,7 @@ module FlightConfiguration
         validate!(config)
       end
     rescue => e
-      raise e, "Cannot load configuration:\n#{e.message}", e.backtrace
+      raise e, "Can not continue as the configuration is invalid:\n#{e.message}", e.backtrace
     end
 
     def merge_sources
@@ -276,7 +276,7 @@ module FlightConfiguration
       end
 
       # Generate the error message
-      msg = "Can not continue as the config is invalid!"
+      msg = ""
 
       # Display generic errors which do not correspond with any attributes
       unless sections[:missing].empty?
@@ -315,7 +315,8 @@ module FlightConfiguration
       end
 
       # Raise the error
-      raise Error, msg
+      # NOTE: The first newline needs to be removed
+      raise Error, msg[1..-1]
     end
   end
 end

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -61,7 +61,6 @@ module FlightConfiguration
       # When extending a class with a *DSL, define the instance methods
       def extended(base)
         base.define_method(:__sources__) { @__sources__ ||= {} }
-        base.define_method(:__reset__) { @__sources__ = {} }
       end
     end
 
@@ -134,7 +133,6 @@ module FlightConfiguration
 
     def load
       new.tap do |config|
-        config.__reset__
         merge_sources.each do |key, source|
           config.__sources__[key] = source
           required = attributes.fetch(key, {})[:required]

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -148,7 +148,7 @@ module FlightConfiguration
         end
 
         # Attempt to validate the config
-        validate(config)
+        validate_config(config)
       end
     rescue => e
       raise e, "Cannot continue as the configuration is invalid:\n#{e.message}", e.backtrace
@@ -247,7 +247,8 @@ module FlightConfiguration
       end
     end
 
-    def validate(config)
+    # The 'validate' method is already used by ActiveValidation, so validate_config is used instead
+    def validate_config(config)
       # Use active errors instead
       if active_errors?
         validate_active_errors(config)

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -107,7 +107,7 @@ module FlightConfiguration
       attr_accessor name.to_s
 
       # Define the accessor that returns the original value
-      define_method("_#{name.to_s}") do
+      define_method("#{name.to_s}_before_type_cast") do
         @__sources__ ||= {}
         @__sources__[name]&.value
       end
@@ -260,7 +260,10 @@ module FlightConfiguration
       # Group errors into their sources
       sections = all_errors.reduce(initial) do |set_memo, errors|
         errors.reduce(set_memo) do |memo, error|
-          key = error.attribute.to_s.sub(/\A_/, '') # Standardise the raw methods (_conf => conf)
+          # Key standardization may not be required, particularly if using ActiveValidation
+          # However it has been retained due to the loose coupling
+          # Consider removing if hard coupling is introduced
+          key = error.attribute.to_s.sub(/_before_type_cast\Z/, '')
           source = sources[key]
           case source&.type
           when NilClass


### PR DESCRIPTION
A new `validate!` class method has been added to the `BaseDSL`, which is called on config load. It attempts to do the following three things:

1. Use `ActiveErrors`/`ActiveValidation` to generate a rich-text validation error,
2. Fallback on a custom `validate!` instance method, OR
3. Otherwise a generic "invalid config" if the `valid?` instance method is defined.

Doing it this way makes validation opt-in, which reduces the barrier for entry when setting up an new application. It also prevents a hard dependency on `active_support`.

NOTE: The new `validate!` class method is currently private, as I don't see a reason to make it public. However it contains the core validation toggle logic.

---

The primary use case for validation is the use of `ActiveValidation`/`ActiveErrors` compatible interface to provide rich error messages. This is triggered by implementing two instance methods:

* `valid?` - Return a boolean if valid and populate the `errors` struct, and
* `errors` - Return the associated errors from `valid?` as a `ActiveMode::Errors` compatible object.

NOTE: Various internal validations will be stored on `errors`, which will be converted to messages before `valid?` is called. The `valid?` method must clear these old errors each time it is called, to prevent them being duplicated. This happens implicitly when using `ActiveValidation`.

---

A lot of the time, the raw config values need to be validated before they are transformed. This is particularly important for integers which are initially defined as strings.

The raw (pre-transformed) config keys are available using the `_key` notation. This is to allow for the following syntax:

```
attribute :my_int
# Validates the raw value instead of the transformed 'my_int' attribute
validates :_my_int, numericality: { only_integers: true }
```

The validation error messages are aware of these "raw values" and will format them together accordingly.

---

The merging of configs has been updated to populate an internal `@__sources__` instance variable on the config. This keeps track where each configuration originated from. These sources become part of the the validation error message to give what went wrong:

```
# NOTE: Yet unreleased version of flight-job
[root@master job]# flight_JOB_minimum_terminal_width=foobar bin/job 
bin/job: Can not continue as the configuration is invalid:

The following environment variable(s) are invalid:
* flight_JOB_minimum_terminal_width: failed to coerce the data type
* flight_JOB_minimum_terminal_width: is not a number

The following config contains invalid attribute(s): /host/job/etc/flight-job.local.yaml
* max_id_length: failed to coerce the data type
* max_id_length: is not a number
```

---

Miscellaneous changes:

* Integers are transformed using `Interger()` instead of `to_i`,
* The `Can not continue as the configuration is invalid:` message has been tweaked,
* A `failed to coerce the data type` message means the transform failed when using ActiveErrors,
* Inbuilt required keys validation hooks into ActiveErrors when available, and
* Missing keys are silently ignored.

Most of these changes are fairly self explanatory barring the "missing keys". Previously the missing keys would emit a `key=` is not defined error, which isn't particularly useful. However I haven't settled if this is a `warn` or `error` condition.

Warnings are difficult to implement at this point, as the `logger` can not be created until after config load. This PR already makes a few changes, so this issue can be dealt with as a future enhancement. 