### PR TITLE
Add a method for logging warnings

### DIFF
--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -66,14 +66,14 @@ module FlightConfiguration
 
       def __logs__
         # Define the order the logs will appear in
-        logs = { fatal: [], error: [], warn: [], info: [], debug: [] }
+        logs = { warn: [], info: [], debug: [] }
 
         # Apply logs from the __sources__
         __sources__.each_with_object(logs) do |(key, source), memo|
           # NOTE: Values are not logged in case they are sensitive
           memo[:debug] << "FC: Config '#{key}' was loaded from: #{source.source}"
           if source.unrecognized
-            memo[:warning] << "FC: Ignoring unrecognized config '#{key}' (source: #{source.source})"
+            memo[:warn] << "FC: Ignoring unrecognized config '#{key}' (source: #{source.source})"
           end
         end
 

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -162,6 +162,7 @@ module FlightConfiguration
           else
             source.unrecognized = true
           end
+          config.__logs__.set_from_source(key, source)
         end
 
         # Attempt to validate the config
@@ -198,7 +199,6 @@ module FlightConfiguration
         # Apply the env vars
         from_env_vars.each do |key, value|
           sources[key] = SourceStruct.new(key, "#{env_var_prefix}_#{key}", :env, value)
-          config.__logs__.set_from_source(key, sources[key])
         end
 
         # Apply the configs
@@ -213,7 +213,6 @@ module FlightConfiguration
             next if sources[key]
             # Ensure the file is a string and not pathname
             sources[key] = SourceStruct.new(key, file.to_s, :file, value)
-            config.__logs__.set_from_source(key, sources[key])
           end
         end
 
@@ -221,7 +220,6 @@ module FlightConfiguration
         defaults.each do |key, value|
           next if sources[key]
           sources[key] = SourceStruct.new(key, nil, :default, value)
-          config.__logs__.set_from_source(key, sources[key])
         end
       end
     end

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -46,7 +46,7 @@ module FlightConfiguration
 
   # Stores a reference to where a particular key came from
   # NOTE: The type specifies if it came from the :env or :file
-  SourceStruct = Struct.new(:key, :source, :type, :value, :missing)
+  SourceStruct = Struct.new(:key, :source, :type, :value, :unrecognized)
 
   # NOTE: This inheritance hierarchy is becoming unwieldy and follows
   #       a extend/include InstanceMethods anti-pattern
@@ -72,8 +72,8 @@ module FlightConfiguration
         __sources__.each_with_object(logs) do |(key, source), memo|
           # NOTE: Values are not logged in case they are sensitive
           memo[:debug] << "FC: Config '#{key}' was loaded from: #{source.source}"
-          if source.missing
-            memo[:warning] << "FC: Ignoring unrecognised config '#{key}' (source: #{source.source})"
+          if source.unrecognized
+            memo[:warning] << "FC: Ignoring unrecognized config '#{key}' (source: #{source.source})"
           end
         end
 
@@ -186,7 +186,7 @@ module FlightConfiguration
           elsif config.respond_to?("#{key}=")
             config.send("#{key}=", transform(config, key, source.value))
           else
-            source.missing = true
+            source.unrecognized = true
           end
         end
 

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -60,40 +60,8 @@ module FlightConfiguration
         @__sources__ ||= {}
       end
 
-      def __files__
-        @__files__ ||= []
-      end
-
       def __logs__
-        # Define the order the logs will appear in
-        logs = { warn: [], info: [], debug: [] }
-
-        # Apply logs from the __sources__
-        __sources__.each_with_object(logs) do |(key, source), memo|
-          # NOTE: Values are not logged in case they are sensitive
-          case source.type
-          when :default
-            memo[:debug] << "FC: Reverting '#{key}' to its default"
-          else
-            memo[:debug] << "FC: Config '#{key}' was loaded from: #{source.source}"
-          end
-
-          if source.unrecognized
-            memo[:warn] << "FC: Ignoring unrecognized config '#{key}' (source: #{source.source})"
-          end
-        end
-
-        # Apply logs from the __files__
-        __files__.each do |file|
-          if File.exists? file
-            logs[:info] << "FC: Loaded configuration: #{file}"
-          else
-            logs[:info] << "FC: Skipped configuration: #{file}"
-          end
-        end
-
-        # Remove empty logs, so the application doesn't have to
-        logs.reject { |_, v| v.empty? }.to_h
+        @__logs__ ||= Logs.new
       end
     end
 
@@ -230,16 +198,22 @@ module FlightConfiguration
         # Apply the env vars
         from_env_vars.each do |key, value|
           sources[key] = SourceStruct.new(key, "#{env_var_prefix}_#{key}", :env, value)
+          config.__logs__.debug "FC: Config '#{key}' loaded from: #{sources[key].source}"
         end
 
         # Apply the configs
         config_files.reverse.each do |file|
-          config.__files__ << file
           hash = from_config_file(file) || {}
+          if File.exists?(file)
+            config.__logs__.info "FC: Loaded #{file}"
+          else
+            config.__logs__.debug "FC: Not found #{file}"
+          end
           hash.each do |key, value|
             next if sources[key]
             # Ensure the file is a string and not pathname
             sources[key] = SourceStruct.new(key, file.to_s, :file, value)
+            config.__logs__.debug "FC: Config '#{key}' loaded from: #{sources[key].source}"
           end
         end
 
@@ -247,6 +221,7 @@ module FlightConfiguration
         defaults.each do |key, value|
           next if sources[key]
           sources[key] = SourceStruct.new(key, nil, :default, value)
+          config.__logs__.debug "FC: Config '#{key}' set to default"
         end
       end
     end

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -198,22 +198,22 @@ module FlightConfiguration
         # Apply the env vars
         from_env_vars.each do |key, value|
           sources[key] = SourceStruct.new(key, "#{env_var_prefix}_#{key}", :env, value)
-          config.__logs__.debug "FC: Config '#{key}' loaded from: #{sources[key].source}"
+          config.__logs__.set_from_source(key, sources[key])
         end
 
         # Apply the configs
         config_files.reverse.each do |file|
           hash = from_config_file(file) || {}
           if File.exists?(file)
-            config.__logs__.info "FC: Loaded #{file}"
+            config.__logs__.file_loaded(file)
           else
-            config.__logs__.debug "FC: Not found #{file}"
+            config.__logs__.file_not_found(file)
           end
           hash.each do |key, value|
             next if sources[key]
             # Ensure the file is a string and not pathname
             sources[key] = SourceStruct.new(key, file.to_s, :file, value)
-            config.__logs__.debug "FC: Config '#{key}' loaded from: #{sources[key].source}"
+            config.__logs__.set_from_source(key, sources[key])
           end
         end
 
@@ -221,7 +221,7 @@ module FlightConfiguration
         defaults.each do |key, value|
           next if sources[key]
           sources[key] = SourceStruct.new(key, nil, :default, value)
-          config.__logs__.debug "FC: Config '#{key}' set to default"
+          config.__logs__.set_from_source(key, sources[key])
         end
       end
     end

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -71,7 +71,13 @@ module FlightConfiguration
         # Apply logs from the __sources__
         __sources__.each_with_object(logs) do |(key, source), memo|
           # NOTE: Values are not logged in case they are sensitive
-          memo[:debug] << "FC: Config '#{key}' was loaded from: #{source.source}"
+          case source.type
+          when :default
+            memo[:debug] << "FC: Reverting '#{key}' to its default"
+          else
+            memo[:debug] << "FC: Config '#{key}' was loaded from: #{source.source}"
+          end
+
           if source.unrecognized
             memo[:warn] << "FC: Ignoring unrecognized config '#{key}' (source: #{source.source})"
           end

--- a/lib/flight_configuration/deep_stringify_keys.rb
+++ b/lib/flight_configuration/deep_stringify_keys.rb
@@ -25,13 +25,19 @@
 # https://github.com/openflighthpc/flight_configuration
 #==============================================================================
 
-require "flight_configuration/version"
-require "flight_configuration/deep_stringify_keys"
-require "flight_configuration/logs"
-require "flight_configuration/base_dsl"
-require "flight_configuration/dsl"
-require "flight_configuration/rack_dsl"
-
 module FlightConfiguration
-  class Error < StandardError; end
+  module DeepStringifyKeys
+    def self.stringify(object)
+      case object
+      when Hash
+        object.each_with_object(object.class.new) do |(key, value), memo|
+          memo[key.to_s] = self.stringify(value)
+        end
+      when Array
+        object.map { |v| self.stringify(v) }
+      else
+        object
+      end
+    end
+  end
 end

--- a/lib/flight_configuration/logs.rb
+++ b/lib/flight_configuration/logs.rb
@@ -25,13 +25,29 @@
 # https://github.com/openflighthpc/flight_configuration
 #==============================================================================
 
-require "flight_configuration/version"
-require "flight_configuration/deep_stringify_keys"
-require "flight_configuration/logs"
-require "flight_configuration/base_dsl"
-require "flight_configuration/dsl"
-require "flight_configuration/rack_dsl"
-
 module FlightConfiguration
-  class Error < StandardError; end
+  class Logs
+    def initialize
+      @logs = []
+    end
+
+    def debug(msg)
+      @logs << [:debug, msg]
+    end
+
+    def info(msg)
+      @logs << [:info, msg]
+    end
+
+    def warn(msg)
+      @logs << [:warn, msg]
+    end
+
+    def log_with(logger)
+      @logs.each do |type, msg|
+        logger.send(type, msg)
+      end
+      @logs.clear
+    end
+  end
 end

--- a/lib/flight_configuration/logs.rb
+++ b/lib/flight_configuration/logs.rb
@@ -31,6 +31,23 @@ module FlightConfiguration
       @logs = []
     end
 
+    def file_loaded(file)
+      info "Loaded #{file}"
+    end
+
+    def file_not_found(file)
+      debug "Not found #{file}"
+    end
+
+    def set_from_source(key, source)
+      if source.type == :default
+        debug "Config '#{key}' set to default"
+      else
+        type = source.type == :env ? 'env var ' : ''
+        debug "Config '#{key}' loaded from #{type}#{source.source}"
+      end
+    end
+
     def debug(msg)
       @logs << [:debug, msg]
     end
@@ -45,7 +62,7 @@ module FlightConfiguration
 
     def log_with(logger)
       @logs.each do |type, msg|
-        logger.send(type, msg)
+        logger.send(type, "FC: #{msg}")
       end
       @logs.clear
     end

--- a/lib/flight_configuration/logs.rb
+++ b/lib/flight_configuration/logs.rb
@@ -40,7 +40,9 @@ module FlightConfiguration
     end
 
     def set_from_source(key, source)
-      if source.type == :default
+      if source.unrecognized
+        warn "Ignoring unrecognized config '#{key}' (source: #{source.source})"
+      elsif source.type == :default
         debug "Config '#{key}' set to default"
       else
         type = source.type == :env ? 'env var ' : ''


### PR DESCRIPTION
A `log_warning` method has been added to the configuration DSL. It processes the `__sources__` struct and logs the missing keys.

It relies on the application setting the `Flight.config` and `Flight.logger` stubs. This way the `config` can be loaded and `logger` configured beforehand.