### PR TITLE
Rework the load method into build

### DIFF
--- a/lib/flight_configuration.rb
+++ b/lib/flight_configuration.rb
@@ -30,8 +30,9 @@ require "flight_configuration/deep_stringify_keys"
 require "flight_configuration/logs"
 require "flight_configuration/base_dsl"
 require "flight_configuration/dsl"
-require "flight_configuration/source_struct"
 require "flight_configuration/rack_dsl"
+require "flight_configuration/rich_active_validation_error_message"
+require "flight_configuration/source_struct"
 
 module FlightConfiguration
   class Error < StandardError; end

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -148,6 +148,11 @@ module FlightConfiguration
       # Defines the default ActiveValidation validators (when applicable)
       if active_validation?
         validates(name, presence: true) if required
+        validate do
+          next if __sources__[name].transformable?
+          @errors.add name, type: :transform,
+            message: 'failed to coerce the data type'
+        end
       end
     end
 

--- a/lib/flight_configuration/base_dsl.rb
+++ b/lib/flight_configuration/base_dsl.rb
@@ -149,7 +149,7 @@ module FlightConfiguration
       if active_validation?
         validates(name, presence: true) if required
         validate do
-          next if __sources__[name].transformable?
+          next if __sources__[name].transform_valid?
           @errors.add name, type: :transform,
             message: 'failed to coerce the data type'
         end

--- a/lib/flight_configuration/fallback_validator.rb
+++ b/lib/flight_configuration/fallback_validator.rb
@@ -33,7 +33,7 @@ module FlightConfiguration
         if source.attribute[:required] && source.value.nil?
           errors << [:missing, source.key]
         end
-        unless source.transformable?
+        unless source.transform_valid?
           errors << [:transform, source.key]
         end
       end

--- a/lib/flight_configuration/logs.rb
+++ b/lib/flight_configuration/logs.rb
@@ -62,6 +62,10 @@ module FlightConfiguration
       @logs << [:warn, msg]
     end
 
+    def error(msg)
+      @logs << [:error, msg]
+    end
+
     def log_with(logger)
       @logs.each do |type, msg|
         logger.send(type, "FC: #{msg}")

--- a/lib/flight_configuration/logs.rb
+++ b/lib/flight_configuration/logs.rb
@@ -40,13 +40,13 @@ module FlightConfiguration
     end
 
     def set_from_source(key, source)
-      if source.unrecognized
-        warn "Ignoring unrecognized config '#{key}' (source: #{source.source})"
-      elsif source.type == :default
+      if source.type == :default
         debug "Config '#{key}' set to default"
-      else
+      elsif source.recognized?
         type = source.type == :env ? 'env var ' : ''
         debug "Config '#{key}' loaded from #{type}#{source.source}"
+      else
+        warn "Ignoring unrecognized config '#{key}' (source: #{source.source})"
       end
     end
 

--- a/lib/flight_configuration/rich_active_validation_error_message.rb
+++ b/lib/flight_configuration/rich_active_validation_error_message.rb
@@ -99,7 +99,7 @@ module FlightConfiguration
     end
 
     def rich_error_message
-      FlightConfiguration::RichActiveValidationError.rich_error_message(self)
+      FlightConfiguration::RichActiveValidationErrorMessage.rich_error_message(self)
     end
   end
 end

--- a/lib/flight_configuration/rich_active_validation_error_message.rb
+++ b/lib/flight_configuration/rich_active_validation_error_message.rb
@@ -1,0 +1,105 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of FlightConfiguration.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightConfiguration is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightConfiguration. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightConfiguration, please visit:
+# https://github.com/openflighthpc/flight_configuration
+#==============================================================================
+
+module FlightConfiguration
+  module RichActiveValidationErrorMessage
+    def self.rich_error_message(config)
+      return nil if config.nil?
+      # Variable definitions
+      sources = config.__sources__
+      initial = { file: {}, env: [], default: [], missing: [] }
+
+      # Group errors into their sources
+      sections = config.errors.reduce(initial) do |memo, error|
+        # Key standardization may not be required, particularly if using ActiveValidation
+        # However it has been retained due to the loose coupling
+        # Consider removing if hard coupling is introduced
+        key = error.attribute.to_s.sub(/_before_type_cast\Z/, '')
+        source = sources[key]
+        case source&.type
+        when NilClass
+          memo[:missing] << [key, error]
+        when :file
+          memo[:file][source.source] ||= []
+          memo[:file][source.source] << [key, error]
+        when :env
+          memo[source.type] << [source.source, error]
+        else
+          memo[source.type] << [key, error]
+        end
+        memo
+      end
+
+      # Generate the error message
+      msg = ""
+
+      # Display generic errors which do not correspond with any attributes
+      unless sections[:missing].empty?
+        msg << "\n\nThe following errors have occurred:"
+        sections[:missing].each do |_, error|
+          msg << "\n* #{error.full_message}"
+        end
+      end
+
+      # Display the environment variables
+      unless sections[:env].empty?
+        msg << "\n\nThe following environment variable(s) are invalid:"
+        sections[:env].each do |env, error|
+          msg << "\n* #{env}: #{error.message}"
+        end
+      end
+
+      # Display errors from a config file
+      config.class.config_files.reverse.map(&:to_s).each do |path|
+        next if sections[:file][path].blank?
+        msg << "\n\nThe following config contains invalid attribute(s): #{path}"
+        sections[:file][path].each do |key, error|
+          msg << "\n* #{key}: #{error.message}"
+        end
+      end
+
+      # Display errors associated with the defaults
+      # NOTE: *Technically* they could error for any validation reason, but the primary
+      # use case is they are missing. A sensible default can not be provided in all cases,
+      # so instead the user should be prompted to provide them.
+      unless sections[:default].empty?
+        msg << "\n\nThe following required attribute(s) have not been set:"
+        sections[:default].map { |k, _| k }.uniq.each do |attr|
+          msg << "\n* #{attr}"
+        end
+      end
+
+      # Return the error
+      # NOTE: The first newline needs to be removed
+      msg[1..-1]
+    end
+
+    def rich_error_message
+      FlightConfiguration::RichActiveValidationError.rich_error_message(self)
+    end
+  end
+end

--- a/lib/flight_configuration/source_struct.rb
+++ b/lib/flight_configuration/source_struct.rb
@@ -54,13 +54,8 @@ module FlightConfiguration
         value.send(transform)
       end
     rescue
-      # # NOTE: Ideally the error would be logged, however this can't be done
-      # #       without forming a recursive loop
-      # if active_errors?
-      #   config.errors.add(key.to_sym, type: :transform, message: 'failed to coerce the data type')
-      # else
-      #   raise Error, "Failed to coerce attribute: #{key}"
-      # end
+      config.__logs__.error("Failed to coerce attribute: #{key}")
+      config.__logs__.debug $!.full_message
       @transformable = false
     end
   end

--- a/lib/flight_configuration/source_struct.rb
+++ b/lib/flight_configuration/source_struct.rb
@@ -25,14 +25,43 @@
 # https://github.com/openflighthpc/flight_configuration
 #==============================================================================
 
-require "flight_configuration/version"
-require "flight_configuration/deep_stringify_keys"
-require "flight_configuration/logs"
-require "flight_configuration/base_dsl"
-require "flight_configuration/dsl"
-require "flight_configuration/source_struct"
-require "flight_configuration/rack_dsl"
-
 module FlightConfiguration
-  class Error < StandardError; end
+  # Stores a reference to where a particular key came from
+  # NOTE: The type specifies if it came from the :env or :file
+  SourceStruct = Struct.new(:key, :source, :type, :value, :config) do
+    def attribute
+      @attribute ||= config.class.attributes[key] || {}
+    end
+
+    def transformable?
+      transformed_value if @transformable.nil?
+      @transformable
+    end
+
+    def recognized?
+      !attribute.empty?
+    end
+
+    def transformed_value
+      return @transformed_value unless @transformable.nil?
+      @transformable = true
+      transform = attribute[:transform]
+      @transformed_value = if transform.nil?
+        value
+      elsif transform.respond_to?(:call)
+        transform.call(value)
+      else
+        value.send(transform)
+      end
+    rescue
+      # # NOTE: Ideally the error would be logged, however this can't be done
+      # #       without forming a recursive loop
+      # if active_errors?
+      #   config.errors.add(key.to_sym, type: :transform, message: 'failed to coerce the data type')
+      # else
+      #   raise Error, "Failed to coerce attribute: #{key}"
+      # end
+      @transformable = false
+    end
+  end
 end

--- a/lib/flight_configuration/source_struct.rb
+++ b/lib/flight_configuration/source_struct.rb
@@ -33,9 +33,9 @@ module FlightConfiguration
       @attribute ||= config.class.attributes[key] || {}
     end
 
-    def transformable?
-      transformed_value if @transformable.nil?
-      @transformable
+    def transform_valid?
+      transformed_value unless defined?(@transform_valid)
+      @transform_valid
     end
 
     def recognized?
@@ -43,8 +43,10 @@ module FlightConfiguration
     end
 
     def transformed_value
-      return @transformed_value unless @transformable.nil?
-      @transformable = true
+      if defined?(@transformed_value)
+        return @transformed_value
+      end
+
       transform = attribute[:transform]
       @transformed_value = if transform.nil?
         value
@@ -56,7 +58,11 @@ module FlightConfiguration
     rescue
       config.__logs__.error("Failed to coerce attribute: #{key}")
       config.__logs__.debug $!.full_message
-      @transformable = false
+      @transform_valid = false
+      nil
+    else
+      @transform_valid = true
+      @transformed_value
     end
   end
 end


### PR DESCRIPTION
Currently the `load` method will error if the validation fails. This prevents the calling application from setting up the `logger`. Instead, `load` has been split in two:

* A new `build` method which will construct the `config` without running the validation, and
* The `load` method which calls build then `validate!`.

---
## Option 1: Formally Integrate with ActiveModel::Validations

The application now need an easy mechanism to validate the config after calling `build`. Ideally this would be as simple as: `Configuration.build.tap {  ...; c.validate! }`.

Previously the `ActiveModel::Validations#validate` method would skip the inbuilt validations due to there ad-hoc implementation. This is highly unexpected and needed to be rectified. Instead, the `atttribute` DSL method know detects the use of active validation, and will implicitly hook into it:

```
    def attribute(name, env_var: true, required: true, default: nil, **opts)
      ...
      # Defines the default ActiveValidation validators (when applicable)
      if active_validation?
        validates(name, presence: true) if required
        validate do
          next if __sources__[name].transformable?
          @errors.add name, type: :transform,
            message: 'failed to coerce the data type'
        end
      end
    end
```

The calling applications may choose to use a new `RichActiveValidationErrorMessage` module to generate the error message. This module defines a `rich_error_message` method which generates a detailed user facing error.

---

## Options 2: Use the default fallback validator

A default validator will be used when `ActiveModel::Valiadtions` is omitted. This validator implements the basic `required` and "did transform error" validations.

This is done via responding to `validate`/`validate!` using `method_missing?`. This prevents the default validator overriding a custom `validate!` method, regardless the order the modules are included/extended. The bulk of the code is stored within `FallbackValidator`

The application _may_ choose to re-implement the `validate!` method, however this method will need to `super` to run the inbuilt checks.

---

## Miscellaneous code changes

The `SourceStruct` has been refactored to contain some of the code which was previously on the `BaseDSL`:

* The `config` is now stored on each `source` so it can be references,
* `unrecognized` attribute has been dropped,
* A `recognized?` method can be implemented by interrogating `config.attributes`,
* The `transform` method has been ported as `transform_value`, and
* Transform errors are now logged.

With these changes, the `SourceStruct` acts as the abstraction to a `key`-`value` pair, taking some of the load off `BaseDSL`. This also makes delaying the validation considerable easier.

*NOTE:* This does _technically_ change the public interface of the `__sources__` hash, however only in a specific and limited manner. As this is an internal object, this change is permissible (barely).

PS: Remove the duplicate instance of `deep_stringify_keys`